### PR TITLE
fix return types & typo so the contract gets built

### DIFF
--- a/contracts/PSP22Emitable/lib.rs
+++ b/contracts/PSP22Emitable/lib.rs
@@ -129,6 +129,12 @@ pub mod psp22_emitable {
                 instance._init_with_admin(caller);
             })
         }
+
+        #[ink(message)]
+        pub fn mint_any_caller(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error> {
+            ink_env::debug_println!("MINT | START");
+            self._mint(account, amount)
+        }
     }
     // EVENT DEFINITIONS #[ink(event)]
     #[ink(event)]

--- a/contracts/stable_coin_new/lib.rs
+++ b/contracts/stable_coin_new/lib.rs
@@ -365,7 +365,7 @@ pub mod stable_coin {
             }
             self._update_current_denominator_e12();
             self.current_interest_rate_e12 = interest_rate_e12;
-            Ok();
+            Ok(())
         }
 
         #[ink(message)]
@@ -373,8 +373,9 @@ pub mod stable_coin {
         fn set_controller_address(
             &mut self,
             new_controller_address: AccountId,
-        ) -> () {
+        ) -> Result<(), PSP22Error>  {
             self.controller_address = new_controller_address;
+            Ok(())
         }
     }
 

--- a/contracts/stable_coin_new/lib.rs
+++ b/contracts/stable_coin_new/lib.rs
@@ -360,11 +360,12 @@ pub mod stable_coin {
 
         #[ink(message)]
         fn be_controlled(&mut self, interest_rate_e12: i128) -> Result<(), PSP22Error> {
-            if self.env().caller() != controller_address {
+            if self.env().caller() != self.controller_address {
                 return Err(PSP22Error::InsufficientBalance); // TODO error name
             }
             self._update_current_denominator_e12();
             self.current_interest_rate_e12 = interest_rate_e12;
+            Ok();
         }
 
         #[ink(message)]
@@ -372,7 +373,7 @@ pub mod stable_coin {
         fn set_controller_address(
             &mut self,
             new_controller_address: AccountId,
-        ) -> Result<(), PSP22Error> {
+        ) -> () {
             self.controller_address = new_controller_address;
         }
     }


### PR DESCRIPTION
As in the title. Couple of return type/typo fixes + addition of mint_any_caller to make writing tests more easy